### PR TITLE
Simplify a little bit

### DIFF
--- a/cmd/decode.go
+++ b/cmd/decode.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
+	"io/ioutil"
+	"os"
+
 	"github.com/jarrodhroberson/bais/bais"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"io/ioutil"
-	"os"
 )
 
 // decodeCmd represents the decode command
@@ -44,7 +45,7 @@ to quickly create a Cobra application.`,
 		if err != nil {
 			panic(err)
 		}
-		decoded, err := bais.Decode(string(content))
+		decoded, err := bais.Decode(nil, string(content))
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/encode.go
+++ b/cmd/encode.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
+	"io/ioutil"
+	"os"
+
 	"github.com/jarrodhroberson/bais/bais"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"io/ioutil"
-	"os"
 )
 
 // encodeCmd represents the encode command
@@ -38,7 +39,7 @@ var encodeCmd = &cobra.Command{
 		if err != nil {
 			panic(err)
 		}
-		encoded := bais.Encode(&content, viper.GetBool("allow-control-characters"))
+		encoded := bais.Encode(content, viper.GetBool("allow-control-characters"))
 		_, err = outputFile.Write([]byte(encoded))
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
getByte: b = bytes[i]; i++
The panic is in the runtime, already, and you don't handle it.

Encode: why does it receive a *[]byte, if it does not modify it?

Is the check of the next 2 bytes with isAsii in Encode OK?
You check that there is +1, +2 bytes remaining, but the same bytes' isAscii...